### PR TITLE
Add support for loading grass76 or grass74

### DIFF
--- a/grass_session/session.py
+++ b/grass_session/session.py
@@ -59,7 +59,7 @@ def get_grass_bin(version=None):
     platform = get_platform_name()
     grassbin_pattern = DEFAULTGRASSBIN.get(platform, DEFAULTBIN)
 
-    versions = [version] if version else ["76", "74"]
+    versions = [version] if version else ["78", "76", "74"]
     for version in versions:
         grassbin = grassbin_pattern.format(version=version)
         try:


### PR DESCRIPTION
This attempts to change the behavior of `get_grass_bin`, by trying to
load the latest version of grass when no version is specified. This
removes the need for callers to specify the correct version, while also
retaining the function's current behavior.