### PR TITLE
Include license file in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+include LICENSE


### PR DESCRIPTION
It would be helpful if the license file was included in the source distribution. 