### PR TITLE
Parse last line of stdout when creating GISBASE

### DIFF
--- a/grass_session/session.py
+++ b/grass_session/session.py
@@ -141,7 +141,7 @@ def get_grass_gisbase(grassbin=None):
                 "variable"
             ).format(grassbin=grassbin)
         )
-    gisbase = out.decode().strip()
+    gisbase = out.decode().strip().split('\n')[-1]
     if not os.path.exists(gisbase):
         raise RuntimeError(
             (


### PR DESCRIPTION
`$GRASSBIN --config path` sometimes returns several lines of output, with the collected GISBASE on the last line.

For example:

```python
out = b'Default locale not found, using UTF-8\n/usr/lib/grass78\n'

# After encoding and stripping, we have:
'Default locale not found, using UTF-8\n/usr/lib/grass78'

# or in cases with only one line, just:
'/usr/lib/grass78'

# With .split('\n')[-1] both cases will result in:
'/usr/lib/grass78'
```