### PR TITLE
grass_session: fix create new LOCATION if GISDBASE dir name has space

### DIFF
--- a/grass_session/session.py
+++ b/grass_session/session.py
@@ -313,7 +313,7 @@ def grass_init(gisbase, gisdb, location, mapset="PERMANENT", env=None, loadlibs=
 
 def grass_create(grassbin, path, create_opts):
     """Create a new location/mapset"""
-    cmd = "{grassbin} -c {create_opts} -e {path}" "".format(
+    cmd = '{grassbin} -c {create_opts} -e "{path}"'.format(
         grassbin=grassbin, create_opts=create_opts, path=path
     )
     proc = subprocess.Popen(


### PR DESCRIPTION
Fixes bug reported here https://github.com/OSGeo/grass/issues/3041.